### PR TITLE
the default command to consume a single message from `__consumer_offsets` is not working with 0.11.x.x+

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You can consume a single message from `__consumer_offsets` as follows:
 ```
 kafka-console-consumer --bootstrap-server localhost:9092 --topic __consumer_offsets --formatter 'kafka.coordinator.GroupMetadataManager$OffsetsMessageFormatter' --max-messages 1
 ```
-*kafka version 0.11.x.x*
+*kafka version 0.11.x.x+*
 ```
 kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic __consumer_offsets --formatter "kafka.coordinator.group.GroupMetadataManager\$OffsetsMessageFormatter" --max-messages 1
 ```

--- a/README.md
+++ b/README.md
@@ -96,9 +96,13 @@ kafka-console-consumer --bootstrap-server localhost:9092 --topic my-topic  --max
 ```
 
 You can consume a single message from `__consumer_offsets` as follows:
-
+*0.9.x.x ~ 0.10.x.x*
 ```
 kafka-console-consumer --bootstrap-server localhost:9092 --topic __consumer_offsets --formatter 'kafka.coordinator.GroupMetadataManager$OffsetsMessageFormatter' --max-messages 1
+```
+*kafka version 0.11.x.x*
+```
+kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic __consumer_offsets --formatter "kafka.coordinator.group.GroupMetadataManager\$OffsetsMessageFormatter" --max-messages 1
 ```
 
 You can consume and specify a consumer group as follows:

--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ kafka-console-consumer --bootstrap-server localhost:9092 --topic my-topic  --max
 ```
 
 You can consume a single message from `__consumer_offsets` as follows:
-*0.9.x.x ~ 0.10.x.x*
+* kafka version 0.9.x.x ~ 0.10.x.x*
 ```
 kafka-console-consumer --bootstrap-server localhost:9092 --topic __consumer_offsets --formatter 'kafka.coordinator.GroupMetadataManager$OffsetsMessageFormatter' --max-messages 1
 ```
-*kafka version 0.11.x.x+*
+* kafka version 0.11.x.x+ *
 ```
 kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic __consumer_offsets --formatter "kafka.coordinator.group.GroupMetadataManager\$OffsetsMessageFormatter" --max-messages 1
 ```


### PR DESCRIPTION
when I ran on my local, the following exception was thrown out.
```
Exception in thread "main" java.lang.ClassNotFoundException: kafka.coordinator.GroupMetadataManager$OffsetsMessageFormatter
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at kafka.tools.ConsoleConsumer$ConsumerConfig.<init>(ConsoleConsumer.scala:370)
	at kafka.tools.ConsoleConsumer$.main(ConsoleConsumer.scala:52)
	at kafka.tools.ConsoleConsumer.main(ConsoleConsumer.scala)
```